### PR TITLE
Fix Buffer deprecations

### DIFF
--- a/lib/toni.js
+++ b/lib/toni.js
@@ -18,7 +18,7 @@ exports.Toni = ( function () {
         , max = Math.max
         , min = Math.min
         // table of powers
-        , bpower = new Buffer( [ 128, 64, 32, 16, 8, 4, 2, 1 ] )
+        , bpower = Buffer.from( [ 128, 64, 32, 16, 8, 4, 2, 1 ] )
         // count the number of bits set to 1 for every 1-byte number
         , cbits = function ( b ) {
            // divide et impera method for 8 bits
@@ -28,7 +28,7 @@ exports.Toni = ( function () {
         }
         , bctable = ( function () {
             var i = 0
-                , table = new Buffer( 256 )
+                , table = Buffer.alloc( 256 )
                 , v = -1
                 ;
             for ( ; i < 256; ++i ) table[ i ] = cbits( i );
@@ -42,7 +42,7 @@ exports.Toni = ( function () {
             // limit range to 4 bytes, (32 bits numbers) using >>> 0
             var r = ( abs( + range ) >>> 0 ) || 1
                 , bytes = max( ceil( r / 8 ), 1 )
-                , bitmap = new Buffer( bytes )
+                , bitmap = Buffer.alloc( bytes )
                 ;
                 bitmap.fill( 0x00 );
                 me.bitmap = bitmap;


### PR DESCRIPTION
Since Node v12, using the Buffer constructor is deprecated. Since causes deprecation warnings when using toni on Node v12.

This PR intends to replace Buffer constructor usages by methods recommended by [the docs](https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe). I'm no expert about buffers at all, so I just followed the documentations and checked that tests are still passing.